### PR TITLE
Fixed issue that sometimes will appear multiple SoulKey instances

### DIFF
--- a/src/main/java/com/buuz135/soulplied_energistics/applied/SoulKey.java
+++ b/src/main/java/com/buuz135/soulplied_energistics/applied/SoulKey.java
@@ -27,7 +27,7 @@ public class SoulKey extends AEKey {
     public static final MapCodec<SoulKey> MAP_CODEC = RecordCodecBuilder.mapCodec(
             builder -> builder
                     .group(Codec.STRING.fieldOf("uhhh_idk").forGetter(o -> ""))
-                    .apply(builder, t1 -> new SoulKey())
+                    .apply(builder, t1 -> INSTANCE)
     );
     public static final Codec<SoulKey> CODEC = MAP_CODEC.codec();
 
@@ -86,6 +86,11 @@ public class SoulKey extends AEKey {
         return false;
     }
 
+    @Override
+    public int hashCode()
+    {
+        return SoulKey.class.hashCode();
+    }
 
     @Override
     public boolean equals(Object obj) {


### PR DESCRIPTION
The current codec may cause multiple distinct SoulKey instances to be created in-game. Since SoulKey does not implement hashCode, attempting to store it inside my custom ae cells designed for SoulKey (or any addon cells that doesn’t constrain AEKey type) results in the AE system treating each instance as a different type. In other words, the same SoulKey effectively “splits” into multiple separate types because multiple distinct instances exist.

I’ve only made a very small change, and it is non-breaking in this pr.