### PR TITLE
Fix: Soul storage not appearing in AE2 network after world reload

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,89 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Client",
+      "presentation": {
+        "group": "Mod Development - Soulplied-Energistics",
+        "order": 0
+      },
+      "projectName": "Soulplied-Energistics",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\clientRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\clientRunVmArgs.txt",
+        "-Dfml.modFolders\u003dsoulplied_energistics%%C:\\Users\\user\\Soulplied-Energistics\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Data",
+      "presentation": {
+        "group": "Mod Development - Soulplied-Energistics",
+        "order": 1
+      },
+      "projectName": "Soulplied-Energistics",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\dataRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\dataRunVmArgs.txt",
+        "-Dfml.modFolders\u003dsoulplied_energistics%%C:\\Users\\user\\Soulplied-Energistics\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "GameTestServer",
+      "presentation": {
+        "group": "Mod Development - Soulplied-Energistics",
+        "order": 2
+      },
+      "projectName": "Soulplied-Energistics",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\gameTestServerRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\gameTestServerRunVmArgs.txt",
+        "-Dfml.modFolders\u003dsoulplied_energistics%%C:\\Users\\user\\Soulplied-Energistics\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Server",
+      "presentation": {
+        "group": "Mod Development - Soulplied-Energistics",
+        "order": 3
+      },
+      "projectName": "Soulplied-Energistics",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\serverRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\serverRunVmArgs.txt",
+        "-Dfml.modFolders\u003dsoulplied_energistics%%C:\\Users\\user\\Soulplied-Energistics\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/bin/main/META-INF/neoforge.mods.toml
+++ b/bin/main/META-INF/neoforge.mods.toml
@@ -1,0 +1,91 @@
+# This is an example mods.toml file. It contains the data relating to the loading mods.
+# There are several mandatory fields (#mandatory), and many more that are optional (#optional).
+# The overall format is standard TOML format, v0.5.0.
+# Note that there are a couple of TOML lists in this file.
+# Find more information on toml format here:  https://github.com/toml-lang/toml
+# The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
+modLoader = "javafml" #mandatory
+# A version range to match for said mod loader - for regular FML @Mod it will be the the FML version. This is currently 47.
+loaderVersion = "[4,)" #mandatory
+# The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
+# Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
+license = "MIT"
+# A URL to refer people to when problems occur with this mod
+#issueTrackerURL="https://change.me.to.your.issue.tracker.example.invalid/" #optional
+# A list of mods - how many allowed here is determined by the individual mod loader
+[[mods]] #mandatory
+# The modid of the mod
+modId = "soulplied_energistics" #mandatory
+# The version number of the mod
+version = "1.0.2" #mandatory
+# A display name for the mod
+displayName = "Soulplied Energistics" #mandatory
+# A URL to query for updates for this mod. See the JSON update specification https://docs.neoforge.net/docs/misc/updatechecker/
+#updateJSONURL="https://change.me.example.invalid/updates.json" #optional
+# A URL for the "homepage" for this mod, displayed in the mod UI
+#displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional
+# A file name (in the root of the mod JAR) containing a logo for display
+#logoFile="soulplied_energistics.png" #optional
+# A text field displayed in the mod UI
+#credits="" #optional
+# A text field displayed in the mod UI
+authors = "Buuz135" #optional
+
+# The description text for the mod (multi line!) (#mandatory)
+description = '''A bridge addon for Industrial Foregoing souls and Applied Energistics'''
+
+# The [[mixins]] block allows you to declare your mixin config to FML so that it gets loaded.
+[[mixins]]
+config = "soulplied_energistics.mixins.json"
+
+# The [[accessTransformers]] block allows you to declare where your AT file is.
+# If this block is omitted, a fallback attempt will be made to load an AT from META-INF/accesstransformer.cfg
+#[[accessTransformers]]
+#file="META-INF/accesstransformer.cfg"
+
+# The coremods config file path is not configurable and is always loaded from META-INF/coremods.json
+
+# A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
+[[dependencies."soulplied_energistics"]] #optional
+# the modid of the dependency
+modId = "neoforge" #mandatory
+# The type of the dependency. Can be one of "required", "optional", "incompatible" or "discouraged" (case insensitive).
+# 'required' requires the mod to exist, 'optional' does not
+# 'incompatible' will prevent the game from loading when the mod exists, and 'discouraged' will show a warning
+type = "required" #mandatory
+# Optional field describing why the dependency is required or why it is incompatible
+# reason="..."
+# The version range of the dependency
+versionRange = "[21,)" #mandatory
+# An ordering relationship for the dependency.
+# BEFORE - This mod is loaded BEFORE the dependency
+# AFTER - This mod is loaded AFTER the dependency
+ordering = "NONE"
+# Side this dependency is applied on - BOTH, CLIENT, or SERVER
+side = "BOTH"
+# Here's another dependency
+[[dependencies."soulplied_energistics"]]
+modId = "minecraft"
+type = "required"
+# This version range declares a minimum of the current minecraft version up to but not including the next major version
+versionRange = "[1.21.1,1.22)"
+ordering = "NONE"
+side = "BOTH"
+[[dependencies."soulplied_energistics"]]
+modId="ae2"
+type="REQUIRED"
+versionRange="[19.0.20-beta,)"
+ordering="AFTER"
+side="BOTH"
+[[dependencies."soulplied_energistics"]]
+modId="industrialforegoingsouls"
+type="REQUIRED"
+versionRange="[1.10.3,)"
+ordering="AFTER"
+side="BOTH"
+
+# Features are specific properties of the game environment, that you may want to declare you require. This example declares
+# that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't
+# stop your mod loading on the server for example.
+#[features."soulplied_energistics"]
+#openGLVersion="[3.2,)"

--- a/bin/main/assets/soulplied_energistics/lang/en_us.json
+++ b/bin/main/assets/soulplied_energistics/lang/en_us.json
@@ -1,0 +1,6 @@
+{
+  "soulkey.name": "Warden Souls",
+  "soulkey.description": "Souls",
+  "soulpliedenergistics.can_be_used_filter":  "*Can be used in AE2 Interface to request souls*",
+  "soulpliedenergistics.storage_bus":  "*Souls can be accessed using an AE2 Storage Bus on the top side*"
+}

--- a/bin/main/assets/soulplied_energistics/lang/ja_jp.json
+++ b/bin/main/assets/soulplied_energistics/lang/ja_jp.json
@@ -1,0 +1,6 @@
+{
+  "soulkey.name": "ウォーデンの魂",
+  "soulkey.description": "魂",
+  "soulpliedenergistics.can_be_used_filter":  "*AE2インターフェースで魂を要求するために使用できます*",
+  "soulpliedenergistics.storage_bus":  "*ソウルは上部のAE2ストレージバスからアクセスできます*"
+}

--- a/bin/main/assets/soulplied_energistics/lang/tr_tr.json
+++ b/bin/main/assets/soulplied_energistics/lang/tr_tr.json
@@ -1,0 +1,6 @@
+{
+  "soulkey.name": "Muhafız Ruhu",
+  "soulkey.description": "Ruhlar",
+  "soulpliedenergistics.can_be_used_filter": "*AE2 Arayüzünde ruh istemek için kullanılabilir*",
+  "soulpliedenergistics.storage_bus": "*Ruhlara üst taraftaki bir AE2 Depolama Veriyolu kullanılarak erişilebilir*"
+}

--- a/bin/main/soulplied_energistics.mixins.json
+++ b/bin/main/soulplied_energistics.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.buuz135.soulplied_energistics.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "refmap": "soulplied_energistics.refmap.json",
+  "mixins": [
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/java/com/buuz135/soulplied_energistics/applied/strategies/SoulExternalStorageStrategy.java
+++ b/src/main/java/com/buuz135/soulplied_energistics/applied/strategies/SoulExternalStorageStrategy.java
@@ -30,13 +30,30 @@ public class SoulExternalStorageStrategy implements ExternalStorageStrategy {
     @Override
     public @Nullable MEStorage createWrapper(boolean b, Runnable runnable) {
         var cap = this.level.getCapability(SoulCapabilities.BLOCK, fromPos, fromSide);
-        if (cap != null){
-            return new SoulLaserDrillMEStorage(cap);
+        if (cap != null) {
+            return new SoulLaserDrillMEStorage(cap, this.level, this.fromPos, this.fromSide, runnable);
         }
+        runnable.run();
         return null;
     }
 
-    private record SoulLaserDrillMEStorage(ISoulHandler baseBlock) implements MEStorage {
+    private static class SoulLaserDrillMEStorage implements MEStorage {
+
+        private final ServerLevel level;
+        private final BlockPos pos;
+        private final Direction side;
+        private final Runnable onChange;
+
+        SoulLaserDrillMEStorage(ISoulHandler baseBlock, ServerLevel level, BlockPos pos, Direction side, Runnable onChange) {
+            this.level = level;
+            this.pos = pos;
+            this.side = side;
+            this.onChange = onChange;
+        }
+
+        private ISoulHandler getCap() {
+            return this.level.getCapability(SoulCapabilities.BLOCK, pos, side);
+        }
 
         @Override
         public boolean isPreferredStorageFor(AEKey what, IActionSource source) {
@@ -45,18 +62,24 @@ public class SoulExternalStorageStrategy implements ExternalStorageStrategy {
 
         @Override
         public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {
-            return baseBlock.fill((int) amount, mode.isSimulate() ? ISoulHandler.Action.SIMULATE : ISoulHandler.Action.EXECUTE);
+            var cap = getCap();
+            if (cap == null) { onChange.run(); return 0; }
+            return cap.fill((int) amount, mode.isSimulate() ? ISoulHandler.Action.SIMULATE : ISoulHandler.Action.EXECUTE);
         }
 
         @Override
         public long extract(AEKey what, long amount, Actionable mode, IActionSource source) {
-            return baseBlock.drain((int) amount, mode.isSimulate() ? ISoulHandler.Action.SIMULATE : ISoulHandler.Action.EXECUTE);
+            var cap = getCap();
+            if (cap == null) { onChange.run(); return 0; }
+            return cap.drain((int) amount, mode.isSimulate() ? ISoulHandler.Action.SIMULATE : ISoulHandler.Action.EXECUTE);
         }
 
         @Override
         public void getAvailableStacks(KeyCounter out) {
-            for (int i = 0; i < baseBlock.getSoulTanks(); i++) {
-                out.add(SoulKey.INSTANCE, baseBlock.getSoulInTank(i));
+            var cap = getCap();
+            if (cap == null) { onChange.run(); return; }
+            for (int i = 0; i < cap.getSoulTanks(); i++) {
+                out.add(SoulKey.INSTANCE, cap.getSoulInTank(i));
             }
         }
 


### PR DESCRIPTION
## Bug Fix

Fixes the issue where souls in the Soul Laser Base completely disappear 
from the AE2 network after restarting the game or reloading the world.

## Root Cause

The `createWrapper` method in `SoulExternalStorageStrategy` was caching 
the capability at creation time. If the Soul Laser Base wasn't fully 
initialized when the Storage Bus loaded, the capability returned null 
and was never retried.

## Fix

- Capability is now re-queried on every access instead of being cached
- If capability is null, `runnable.run()` is called to signal AE2 to 
  retry — this is the intended mechanism for this use case
- Converted `SoulLaserDrillMEStorage` from a record to a class to 
  support the new live-query approach

## Related

Closes #5