### PR TITLE
Fix SoulKey identity bugs causing wrong values after world reload + Storage Monitor face render

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,89 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Client",
+      "presentation": {
+        "group": "Mod Development - Soulplied-Energistics",
+        "order": 0
+      },
+      "projectName": "Soulplied-Energistics",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\clientRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\clientRunVmArgs.txt",
+        "-Dfml.modFolders\u003dsoulplied_energistics%%C:\\Users\\user\\Soulplied-Energistics\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Data",
+      "presentation": {
+        "group": "Mod Development - Soulplied-Energistics",
+        "order": 1
+      },
+      "projectName": "Soulplied-Energistics",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\dataRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\dataRunVmArgs.txt",
+        "-Dfml.modFolders\u003dsoulplied_energistics%%C:\\Users\\user\\Soulplied-Energistics\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "GameTestServer",
+      "presentation": {
+        "group": "Mod Development - Soulplied-Energistics",
+        "order": 2
+      },
+      "projectName": "Soulplied-Energistics",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\gameTestServerRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\gameTestServerRunVmArgs.txt",
+        "-Dfml.modFolders\u003dsoulplied_energistics%%C:\\Users\\user\\Soulplied-Energistics\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Server",
+      "presentation": {
+        "group": "Mod Development - Soulplied-Energistics",
+        "order": 3
+      },
+      "projectName": "Soulplied-Energistics",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\serverRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\user\\Soulplied-Energistics\\build\\moddev\\serverRunVmArgs.txt",
+        "-Dfml.modFolders\u003dsoulplied_energistics%%C:\\Users\\user\\Soulplied-Energistics\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/bin/main/META-INF/neoforge.mods.toml
+++ b/bin/main/META-INF/neoforge.mods.toml
@@ -1,0 +1,91 @@
+# This is an example mods.toml file. It contains the data relating to the loading mods.
+# There are several mandatory fields (#mandatory), and many more that are optional (#optional).
+# The overall format is standard TOML format, v0.5.0.
+# Note that there are a couple of TOML lists in this file.
+# Find more information on toml format here:  https://github.com/toml-lang/toml
+# The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
+modLoader = "javafml" #mandatory
+# A version range to match for said mod loader - for regular FML @Mod it will be the the FML version. This is currently 47.
+loaderVersion = "[4,)" #mandatory
+# The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
+# Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
+license = "MIT"
+# A URL to refer people to when problems occur with this mod
+#issueTrackerURL="https://change.me.to.your.issue.tracker.example.invalid/" #optional
+# A list of mods - how many allowed here is determined by the individual mod loader
+[[mods]] #mandatory
+# The modid of the mod
+modId = "soulplied_energistics" #mandatory
+# The version number of the mod
+version = "1.0.2" #mandatory
+# A display name for the mod
+displayName = "Soulplied Energistics" #mandatory
+# A URL to query for updates for this mod. See the JSON update specification https://docs.neoforge.net/docs/misc/updatechecker/
+#updateJSONURL="https://change.me.example.invalid/updates.json" #optional
+# A URL for the "homepage" for this mod, displayed in the mod UI
+#displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional
+# A file name (in the root of the mod JAR) containing a logo for display
+#logoFile="soulplied_energistics.png" #optional
+# A text field displayed in the mod UI
+#credits="" #optional
+# A text field displayed in the mod UI
+authors = "Buuz135" #optional
+
+# The description text for the mod (multi line!) (#mandatory)
+description = '''A bridge addon for Industrial Foregoing souls and Applied Energistics'''
+
+# The [[mixins]] block allows you to declare your mixin config to FML so that it gets loaded.
+[[mixins]]
+config = "soulplied_energistics.mixins.json"
+
+# The [[accessTransformers]] block allows you to declare where your AT file is.
+# If this block is omitted, a fallback attempt will be made to load an AT from META-INF/accesstransformer.cfg
+#[[accessTransformers]]
+#file="META-INF/accesstransformer.cfg"
+
+# The coremods config file path is not configurable and is always loaded from META-INF/coremods.json
+
+# A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
+[[dependencies."soulplied_energistics"]] #optional
+# the modid of the dependency
+modId = "neoforge" #mandatory
+# The type of the dependency. Can be one of "required", "optional", "incompatible" or "discouraged" (case insensitive).
+# 'required' requires the mod to exist, 'optional' does not
+# 'incompatible' will prevent the game from loading when the mod exists, and 'discouraged' will show a warning
+type = "required" #mandatory
+# Optional field describing why the dependency is required or why it is incompatible
+# reason="..."
+# The version range of the dependency
+versionRange = "[21,)" #mandatory
+# An ordering relationship for the dependency.
+# BEFORE - This mod is loaded BEFORE the dependency
+# AFTER - This mod is loaded AFTER the dependency
+ordering = "NONE"
+# Side this dependency is applied on - BOTH, CLIENT, or SERVER
+side = "BOTH"
+# Here's another dependency
+[[dependencies."soulplied_energistics"]]
+modId = "minecraft"
+type = "required"
+# This version range declares a minimum of the current minecraft version up to but not including the next major version
+versionRange = "[1.21.1,1.22)"
+ordering = "NONE"
+side = "BOTH"
+[[dependencies."soulplied_energistics"]]
+modId="ae2"
+type="REQUIRED"
+versionRange="[19.0.20-beta,)"
+ordering="AFTER"
+side="BOTH"
+[[dependencies."soulplied_energistics"]]
+modId="industrialforegoingsouls"
+type="REQUIRED"
+versionRange="[1.10.3,)"
+ordering="AFTER"
+side="BOTH"
+
+# Features are specific properties of the game environment, that you may want to declare you require. This example declares
+# that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't
+# stop your mod loading on the server for example.
+#[features."soulplied_energistics"]
+#openGLVersion="[3.2,)"

--- a/bin/main/assets/soulplied_energistics/lang/en_us.json
+++ b/bin/main/assets/soulplied_energistics/lang/en_us.json
@@ -1,0 +1,6 @@
+{
+  "soulkey.name": "Warden Souls",
+  "soulkey.description": "Souls",
+  "soulpliedenergistics.can_be_used_filter":  "*Can be used in AE2 Interface to request souls*",
+  "soulpliedenergistics.storage_bus":  "*Souls can be accessed using an AE2 Storage Bus on the top side*"
+}

--- a/bin/main/assets/soulplied_energistics/lang/ja_jp.json
+++ b/bin/main/assets/soulplied_energistics/lang/ja_jp.json
@@ -1,0 +1,6 @@
+{
+  "soulkey.name": "ウォーデンの魂",
+  "soulkey.description": "魂",
+  "soulpliedenergistics.can_be_used_filter":  "*AE2インターフェースで魂を要求するために使用できます*",
+  "soulpliedenergistics.storage_bus":  "*ソウルは上部のAE2ストレージバスからアクセスできます*"
+}

--- a/bin/main/assets/soulplied_energistics/lang/tr_tr.json
+++ b/bin/main/assets/soulplied_energistics/lang/tr_tr.json
@@ -1,0 +1,6 @@
+{
+  "soulkey.name": "Muhafız Ruhu",
+  "soulkey.description": "Ruhlar",
+  "soulpliedenergistics.can_be_used_filter": "*AE2 Arayüzünde ruh istemek için kullanılabilir*",
+  "soulpliedenergistics.storage_bus": "*Ruhlara üst taraftaki bir AE2 Depolama Veriyolu kullanılarak erişilebilir*"
+}

--- a/bin/main/soulplied_energistics.mixins.json
+++ b/bin/main/soulplied_energistics.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.buuz135.soulplied_energistics.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "refmap": "soulplied_energistics.refmap.json",
+  "mixins": [
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/java/com/buuz135/soulplied_energistics/applied/SoulKey.java
+++ b/src/main/java/com/buuz135/soulplied_energistics/applied/SoulKey.java
@@ -27,7 +27,7 @@ public class SoulKey extends AEKey {
     public static final MapCodec<SoulKey> MAP_CODEC = RecordCodecBuilder.mapCodec(
             builder -> builder
                     .group(Codec.STRING.fieldOf("uhhh_idk").forGetter(o -> ""))
-                    .apply(builder, t1 -> new SoulKey())
+                    .apply(builder, t1 -> SoulKey.INSTANCE)
     );
     public static final Codec<SoulKey> CODEC = MAP_CODEC.codec();
 
@@ -53,7 +53,8 @@ public class SoulKey extends AEKey {
 
     @Override
     public Object getPrimaryKey() {
-        return this;
+        // KeyCounter indexes by primaryKey using identity (==); must be stable across instances.
+        return SoulKey.class;
     }
 
     @Override
@@ -90,5 +91,11 @@ public class SoulKey extends AEKey {
     @Override
     public boolean equals(Object obj) {
         return obj instanceof SoulKey;
+    }
+
+    @Override
+    public int hashCode() {
+        // Constant to honor the equals/hashCode contract — all SoulKey instances are equal.
+        return SoulKey.class.hashCode();
     }
 }

--- a/src/main/java/com/buuz135/soulplied_energistics/applied/strategies/SoulExternalStorageStrategy.java
+++ b/src/main/java/com/buuz135/soulplied_energistics/applied/strategies/SoulExternalStorageStrategy.java
@@ -30,13 +30,30 @@ public class SoulExternalStorageStrategy implements ExternalStorageStrategy {
     @Override
     public @Nullable MEStorage createWrapper(boolean b, Runnable runnable) {
         var cap = this.level.getCapability(SoulCapabilities.BLOCK, fromPos, fromSide);
-        if (cap != null){
-            return new SoulLaserDrillMEStorage(cap);
+        if (cap != null) {
+            return new SoulLaserDrillMEStorage(cap, this.level, this.fromPos, this.fromSide, runnable);
         }
+        runnable.run();
         return null;
     }
 
-    private record SoulLaserDrillMEStorage(ISoulHandler baseBlock) implements MEStorage {
+    private static class SoulLaserDrillMEStorage implements MEStorage {
+
+        private final ServerLevel level;
+        private final BlockPos pos;
+        private final Direction side;
+        private final Runnable onChange;
+
+        SoulLaserDrillMEStorage(ISoulHandler baseBlock, ServerLevel level, BlockPos pos, Direction side, Runnable onChange) {
+            this.level = level;
+            this.pos = pos;
+            this.side = side;
+            this.onChange = onChange;
+        }
+
+        private ISoulHandler getCap() {
+            return this.level.getCapability(SoulCapabilities.BLOCK, pos, side);
+        }
 
         @Override
         public boolean isPreferredStorageFor(AEKey what, IActionSource source) {
@@ -45,18 +62,24 @@ public class SoulExternalStorageStrategy implements ExternalStorageStrategy {
 
         @Override
         public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {
-            return baseBlock.fill((int) amount, mode.isSimulate() ? ISoulHandler.Action.SIMULATE : ISoulHandler.Action.EXECUTE);
+            var cap = getCap();
+            if (cap == null) { onChange.run(); return 0; }
+            return cap.fill((int) amount, mode.isSimulate() ? ISoulHandler.Action.SIMULATE : ISoulHandler.Action.EXECUTE);
         }
 
         @Override
         public long extract(AEKey what, long amount, Actionable mode, IActionSource source) {
-            return baseBlock.drain((int) amount, mode.isSimulate() ? ISoulHandler.Action.SIMULATE : ISoulHandler.Action.EXECUTE);
+            var cap = getCap();
+            if (cap == null) { onChange.run(); return 0; }
+            return cap.drain((int) amount, mode.isSimulate() ? ISoulHandler.Action.SIMULATE : ISoulHandler.Action.EXECUTE);
         }
 
         @Override
         public void getAvailableStacks(KeyCounter out) {
-            for (int i = 0; i < baseBlock.getSoulTanks(); i++) {
-                out.add(SoulKey.INSTANCE, baseBlock.getSoulInTank(i));
+            var cap = getCap();
+            if (cap == null) { onChange.run(); return; }
+            for (int i = 0; i < cap.getSoulTanks(); i++) {
+                out.add(SoulKey.INSTANCE, cap.getSoulInTank(i));
             }
         }
 

--- a/src/main/java/com/buuz135/soulplied_energistics/client/SoulKeyRenderHandler.java
+++ b/src/main/java/com/buuz135/soulplied_energistics/client/SoulKeyRenderHandler.java
@@ -11,8 +11,11 @@ import com.mojang.math.Axis;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 
 import java.util.ArrayList;
@@ -83,8 +86,79 @@ public class SoulKeyRenderHandler implements AEKeyRenderHandler<SoulKey> {
     }
 
     @Override
-    public void drawOnBlockFace(PoseStack poseStack, MultiBufferSource multiBufferSource, SoulKey soulKey, float v, int i, Level level) {
+    public void drawOnBlockFace(PoseStack poseStack, MultiBufferSource buffers, SoulKey soulKey, float scale,
+                                int combinedLight, Level level) {
+        var wardenTex = ResourceLocation.withDefaultNamespace("textures/entity/warden/warden.png");
+        var heartTex = ResourceLocation.withDefaultNamespace("textures/entity/warden/warden_heart.png");
 
+        poseStack.pushPose();
+        poseStack.translate(0, 0, 0.01f);
+
+        // Warden head sprite is at u=12..28, v=14..30 in 128x128 atlas
+        var headU0 = 12f / 128f;
+        var headV0 = 14f / 128f;
+        var headU1 = 28f / 128f;
+        var headV1 = 30f / 128f;
+
+        // Warden heart sprite is at u=11..29, v=13..31 in 128x128 atlas
+        var heartU0 = 11f / 128f;
+        var heartV0 = 13f / 128f;
+        var heartU1 = 29f / 128f;
+        var heartV1 = 31f / 128f;
+
+        var faceScale = scale - 0.05f;
+        var heartScale = faceScale * 1.12f;
+
+        // Pulsing heart layer (behind the head)
+        long gameTime = level != null ? level.getGameTime() : 0L;
+        float heartPulse = 1f - ((gameTime % 30L) / 30f);
+        int heartAlpha = Mth.clamp((int) (heartPulse * 255f), 0, 255);
+        int heartColor = (heartAlpha << 24) | 0xFFFFFF;
+
+        drawQuad(poseStack, buffers.getBuffer(RenderType.entityTranslucent(heartTex)),
+                heartScale, heartU0, heartV0, heartU1, heartV1, heartColor, combinedLight);
+
+        // Warden head on top
+        poseStack.translate(0, 0, 0.005f);
+        drawQuad(poseStack, buffers.getBuffer(RenderType.entityCutoutNoCull(wardenTex)),
+                faceScale, headU0, headV0, headU1, headV1, 0xFFFFFFFF, combinedLight);
+
+        poseStack.popPose();
+    }
+
+    private static void drawQuad(PoseStack poseStack, com.mojang.blaze3d.vertex.VertexConsumer buffer,
+                                 float size, float u0, float v0, float u1, float v1,
+                                 int color, int combinedLight) {
+        var x0 = -size / 2f;
+        var y0 = size / 2f;
+        var x1 = size / 2f;
+        var y1 = -size / 2f;
+        var transform = poseStack.last().pose();
+
+        buffer.addVertex(transform, x0, y1, 0)
+                .setColor(color)
+                .setUv(u0, v1)
+                .setOverlay(OverlayTexture.NO_OVERLAY)
+                .setLight(combinedLight)
+                .setNormal(0, 0, 1);
+        buffer.addVertex(transform, x1, y1, 0)
+                .setColor(color)
+                .setUv(u1, v1)
+                .setOverlay(OverlayTexture.NO_OVERLAY)
+                .setLight(combinedLight)
+                .setNormal(0, 0, 1);
+        buffer.addVertex(transform, x1, y0, 0)
+                .setColor(color)
+                .setUv(u1, v0)
+                .setOverlay(OverlayTexture.NO_OVERLAY)
+                .setLight(combinedLight)
+                .setNormal(0, 0, 1);
+        buffer.addVertex(transform, x0, y0, 0)
+                .setColor(color)
+                .setUv(u0, v0)
+                .setOverlay(OverlayTexture.NO_OVERLAY)
+                .setLight(combinedLight)
+                .setNormal(0, 0, 1);
     }
 
     @Override


### PR DESCRIPTION
## Summary

This PR bundles four fixes that all stem from the `SoulKey` and `SoulKeyRenderHandler` classes. It also includes the capability re-query fix originally proposed in #12 (which this PR supersedes), so the soul-related issues can be resolved together.

## Bugs fixed

### 1. Storage Monitor / ME Level Emitter (incl. Extended AE Threshold Emitter) read 0 souls after world reload

After saving and reloading the world, AE2 components configured to track souls would display 0 (Storage Monitor) or trigger redstone incorrectly (Level Emitter / Threshold Emitter), even when the soul count in the network was non-zero. Right-clicking the filter slot with a soul item to "reset" the configured key fixed the display until the next reload.

Three independent identity bugs in `SoulKey` were responsible:

1. **Codec created a fresh `new SoulKey()` on every NBT decode**, breaking identity-based comparisons against `SoulKey.INSTANCE`.
2. **`equals()` was overridden but `hashCode()` was not**, violating the Java contract. AE2's `AEKey2LongMap` (an `Object2LongOpenHashMap`) sent equal `SoulKey` instances to different buckets via the inherited identity hash.
3. **`getPrimaryKey()` returned `this`**. AE2's `KeyCounter` indexes its outer `Reference2ObjectOpenHashMap` by `primaryKey` using `==` comparison, so each `SoulKey` instance produced its own bucket. `AEItemKey` returns the singleton `Item`; this PR follows the same pattern and returns `SoulKey.class`.

### 2. Storage Monitor face displayed nothing

`SoulKeyRenderHandler.drawOnBlockFace` was a no-op, so the warden icon visible in inventories never appeared on Storage Monitor faces. Implemented a quad-based renderer for the warden head with a pulsing heart underlay.

### 3. (from #12) Souls disappear from AE network after world reload

Already on this branch via the prior commit `485af0a`. `SoulExternalStorageStrategy.createWrapper` cached the capability; if the Soul Laser Base wasn't fully initialized when the Storage Bus loaded, the cached capability stayed `null` permanently. The strategy now re-queries the capability on every access and signals AE2 to retry via `runnable.run()` when null is observed.

## Verified by

- Storage Monitor displays the correct soul count after world close+reopen, no manual reset needed.
- Extended AE's Threshold Emitter triggers redstone correctly per its hysteresis configuration after reload.
- Storage Monitor face shows the warden head with a pulsing heart.
- Soul totals in the AE2 grid persist correctly across reloads (existing fix from #12).

## Notes

- Existing worlds may need a one-time reset of pre-existing monitors/emitters whose saved configured-key reference is from the broken state. After the reset, the value persists across reloads.
- Closes #12 (this PR includes that fix as a prior commit and adds the broader identity-bug fixes on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)